### PR TITLE
Add optimizer zero_grad call in only_texture case

### DIFF
--- a/escher/main.py
+++ b/escher/main.py
@@ -547,6 +547,8 @@ class Escher:
                         global_rotation=True, map_type=self.constraint_data.get_global_transformation_type()
                     )
                     mapped = GlobalDeformation.map(mapped, global_A)
+            else:
+                self.optimizer.zero_grad()
 
             if self.args.BW:
                 texture = torch.tile(self.color_parameters[:, :, :, :1], (1, 1, 1, 3))


### PR DESCRIPTION
I don't know whether ONLY_TEXTURE_FROM_THIS_POINT is experimental. But it seems the optimizer zero_grad call is missing after THIS_POINT.